### PR TITLE
Add memory.json to the git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 config.json
+memory.json
 listeners-enabled/*
 plugins-enabled/*
 !listeners-enabled/.gitkeep


### PR DESCRIPTION
`memory.json` created by the memory plugin is not present in the git ignore list.